### PR TITLE
add chain ids and identifiers' hrp mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Sub-modules:
 - `txnmetadata`: utils for creating peer to peer transaction metadata. [LIP-4](https://lip.libra.org/lip-4/)
 - `testnet`: Testnet utility, minting coins, create Testnet client, chain id, Testnet JSON-RPC URL.
 - `LocalAccount` | `local_account`: utility for managing local account keys, generate random local account.
+- `chain_ids`: list of static chain ids
 
 ## Examples
 

--- a/src/libra/chain_ids.py
+++ b/src/libra/chain_ids.py
@@ -1,0 +1,22 @@
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Defines available static chain ids
+
+```python
+
+from libra import chain_ids
+
+# print chain id's int value
+print(chain_ids.TESTING.to_int())
+```
+
+"""
+
+from .libra_types import ChainId
+
+MAINNET: ChainId = ChainId.from_int(1)
+TESTNET: ChainId = ChainId.from_int(2)
+DEVNET: ChainId = ChainId.from_int(3)
+TESTING: ChainId = ChainId.from_int(4)
+PREMAINNET: ChainId = ChainId.from_int(19)

--- a/src/libra/identifier.py
+++ b/src/libra/identifier.py
@@ -4,6 +4,15 @@
 """LIP-5 Libra Account Identifier and Intent Identifier Utilities.
 
 See https://lip.libra.org/lip-5 for more details
+
+```python
+
+from libra import chain_ids, identifier
+
+# print hrp for premainnet by premainnet chain id
+print(identifier.HRPS[chain_ids.PREMAINNET.to_int()])
+```
+
 """
 
 
@@ -11,10 +20,20 @@ import typing
 from urllib import parse
 from typing import List
 
-from . import libra_types, utils
+from . import libra_types, utils, chain_ids
 
 LBR = "lbr"  # lbr for mainnet
 TLB = "tlb"  # tlb for testnet
+PLB = "plb"  # plb for premainnet
+
+HRPS: typing.Dict[int, str] = {
+    chain_ids.MAINNET.to_int(): LBR,
+    chain_ids.TESTNET.to_int(): TLB,
+    chain_ids.DEVNET.to_int(): TLB,
+    chain_ids.TESTING.to_int(): TLB,
+    chain_ids.PREMAINNET.to_int(): PLB,
+}
+
 LIBRA_SUBADDRESS_SIZE = 8  # in bytes (for V1)
 LIBRA_ZERO_SUBADDRESS: bytes = b"\0" * LIBRA_SUBADDRESS_SIZE
 

--- a/src/libra/libra_types/__init__.py
+++ b/src/libra/libra_types/__init__.py
@@ -76,6 +76,16 @@ class BlockMetadata:
 class ChainId:
     value: st.uint8
 
+    # TODO: generate the following 2 methods instead of hardcode
+    # when regen this file, add these to methods back before we can generate them.
+
+    @staticmethod
+    def from_int(id: int) -> "ChainId":
+        return ChainId(value=st.uint8(id))
+
+    def to_int(self) -> int:
+        return int(self.value)
+
     def lcs_serialize(self) -> bytes:
         return lcs.serialize(self, ChainId)
 

--- a/src/libra/testnet.py
+++ b/src/libra/testnet.py
@@ -23,12 +23,12 @@ account: LocalAccount = faucet.gen_account()
 import requests
 import typing
 
-from . import libra_types, jsonrpc, utils, local_account, serde_types, auth_key
+from . import libra_types, jsonrpc, utils, local_account, serde_types, auth_key, chain_ids
 
 
-JSON_RPC_URL = "https://testnet.libra.org/v1"
-FAUCET_URL = "https://testnet.libra.org/mint"
-CHAIN_ID = libra_types.ChainId(value=serde_types.uint8(2))  # pyre-ignore
+JSON_RPC_URL: str = "https://testnet.libra.org/v1"
+FAUCET_URL: str = "https://testnet.libra.org/mint"
+CHAIN_ID: libra_types.ChainId = chain_ids.TESTNET
 
 DESIGNATED_DEALER_ADDRESS: libra_types.AccountAddress = utils.account_address("000000000000000000000000000000dd")
 TEST_CURRENCY_CODE: str = "Coin1"

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -15,6 +15,10 @@ enocded_addr_with_none_subaddr = "lbr1p7ujcndcl7nudzwt8fglhx6wxnvqqqqqqqqqqqqqfl
 enocded_addr_with_subaddr = "lbr1p7ujcndcl7nudzwt8fglhx6wxn08kgs5tm6mz4usw5p72t"
 
 
+def test_identifier_hrps():
+    assert identifier.HRPS == {1: "lbr", 2: "tlb", 3: "tlb", 4: "tlb", 19: "plb"}
+
+
 def test_encode_addr_success():
     # test with none sub_address
     enocded_addr = identifier.encode_account(test_onchain_address, None, "lbr")


### PR DESCRIPTION
HRPS mapping is useful for get back hrp by a configured chain id which is int value.