### PR TITLE
remove an invalid test and fix a method annotation bug

### DIFF
--- a/src/libra/txnmetadata.py
+++ b/src/libra/txnmetadata.py
@@ -32,7 +32,7 @@ class Attest:
 
 def travel_rule(
     off_chain_reference_id: str, sender_address: libra_types.AccountAddress, amount: int
-) -> typing.Tuple[(bytes, bytes)]:
+) -> typing.Tuple[bytes, bytes]:
     """Create travel rule metadata bytes and signature message bytes.
 
     This is used for peer to peer transfer between 2 custodial accounts.

--- a/tests/test_testnet.py
+++ b/tests/test_testnet.py
@@ -232,14 +232,6 @@ def test_get_account_state_with_proof():
     assert state_proof.version == client.get_last_known_state().version
 
 
-def test_get_account_state_with_proof_with_version():
-    client = testnet.create_client()
-    ret = client.get_account_state_with_proof(testnet.DESIGNATED_DEALER_ADDRESS, 3, 4)
-    assert ret is not None
-    assert isinstance(ret, jsonrpc.AccountStateWithProof)
-    assert ret.version == 3
-
-
 def test_handle_stale_response_error():
     client = testnet.create_client()
     last = client.get_metadata().version


### PR DESCRIPTION
test_get_account_state_with_proof_with_version is removed because: 
Server side drops old account state data, hence request will fail when we request a very old version.
Hence this test is not valid, and we need fix server side by removing the version params too.